### PR TITLE
please remove deblok

### DIFF
--- a/mainUnblockers.md
+++ b/mainUnblockers.md
@@ -29,7 +29,7 @@ This is a collection of links of proxies, games, AI, and apps. <br>
 
 ## Updates/Changes:
 ### April 9: <br> 50+ more [Abyss!!](#newhopesinfo-links)
-**April 8:** 15+ more [Abyss](#abyss-misc-links), 15+ more [Artclass](#not-hopsh-links), NEW [12ft](#12ft--proxy) Proxy, NEW [Deblok](#deblok) site! More [Utopia](#utopia--proxy-games-ai) <br>
+**April 8:** 15+ more [Abyss](#abyss-misc-links), 15+ more [Artclass](#not-hopsh-links), NEW [12ft](#12ft--proxy) Proxy, NEW Deblok site! More [Utopia](#utopia--proxy-games-ai) <br>
 **April 5:** 30+ More [Abyss](#showmyhomescom-links), 15+ more [Astroid](#astroid--games-emulators-apps-and-proxy--to-access-click-any-button-on-the-math-is-fun-page), 5+ more [Shadow Browser](#shadow-broswer--web-browser), NEW [Sunset Network](#sunset-network--proxy-games-apps) links (proxy, games, apps), NEW [Skydiver-web](#skydiver-web--web-browser) links (web browser + ai & apps)! <br>
 **April 2:**  50+ More [Abyss](#abyss--web-browser--games),  10+ more [Artclass](#artclass--games-apps-proxy-and-emulators), 10+ NEW [Platformer.io](#platformer--proxy-games) Sites (has proxy & games),  NEW [Equinox](#equinox--proxy-games-apps) site (has proxy, games, apps)  <br>
 **March 31:** 35+ More [Abyss](#abyss--web-browser--games), 10+ more [Homework Help](#homework-help--games-proxy), Added [Google Form](https://forms.gle/FaHsGQxFTnZ6uSvn9) to report a link, suggest, or donate one. Happy Spring Break! <br>
@@ -67,7 +67,6 @@ This is a collection of links of proxies, games, AI, and apps. <br>
 - 5+ [**Tinf0il**](#tinf0il--games-proxy-apps) - Proxy, Games, Apps
 - <5 [NEW Ludicrous](#new-ludicrous--proxy) - Proxy
 - <5 [Incognito](#incognito--proxy-games-apps) - Proxy, Games, Apps
-- <5 [Deblok](#deblok) - Proxy
 - [1-2 link sites, including 12+ sites and 20+ links](#sites-with-1-2-links) - Includes proxies, web browsers, games, & apps
 - 20+ **[AI](#ai-and-homework-solvers)**
   * 5+ [Homework Solvers/Calculators](#homework-solverscalculators-)
@@ -787,13 +786,6 @@ https://km8y68.csb.app/ <br>
 https://y9ze2o.csb.app/# <br>
 <br>
 **^ Back to [top ^](https://github.com/wea-f/ByePassHub/blob/main/mainUnblockers.md#shortcuts--table-of-contents)**
-
-### Deblok
-Join the [Deblok](https://discord.gg/deblok) discord server to sign up.
-**NEW** https://mass.harvard.education.us.soapagent.com/#/login <br>
-**NEW** https://api.learnnexus.site/#/login <br>
-**NEW** https://reading-k3.learnnexus.site/#/login <br>
-**NEW** https://math-k3.learnnexus.site/#/login <br>
 
 ---
 ### Sites with 1-2 links


### PR DESCRIPTION
found your repo because of my cloudflare analytics referers
![image](https://github.com/wea-f/ByePassHub/assets/86028086/34ee87be-71b9-4a66-ad9b-c8e495201550)

now please take down my links, or else.
PS: Thank you for complying with everyone else who requests to take down their links. I own Deblok.
